### PR TITLE
Fix Darwin build

### DIFF
--- a/fuse/aefsfuse.c
+++ b/fuse/aefsfuse.c
@@ -30,8 +30,13 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <sys/vfs.h>
 #include <pthread.h>
+
+#ifdef __APPLE__
+#include <sys/mount.h>
+#else
+#include <sys/vfs.h>
+#endif
 
 #include "getopt.h"
 


### PR DESCRIPTION
Use `sys/mount.h` instead of `sys/vfs.h` on Darwin.
